### PR TITLE
Refactor model loading and API configuration

### DIFF
--- a/call_mutilmodal.py
+++ b/call_mutilmodal.py
@@ -10,14 +10,22 @@ from glob import glob
 import openai
 from tqdm import tqdm  # 新增
 import time
+import tomllib
 # import ZhiPUAI
 # # OpenAI 初始化
 # client = openai.OpenAI(
 #     api_key="sk-MnAWpDIEPZid_w-oeZVjZLLw-XehhhPCSwumOVKu2WT3BlbkFJsgTLbZWkYi3akrNnamWh96rOclJofmj8oXi9k3MagA"
 # )
 
-processor = Blip2Processor.from_pretrained("Salesforce/blip2-opt-2.7b")
-blip_model = Blip2ForConditionalGeneration.from_pretrained("Salesforce/blip2-opt-2.7b").to("cuda")
+with open("config.toml", "rb") as f:
+    CONFIG = tomllib.load(f)
+
+MODEL_BASE = CONFIG["model"]["base_dir"]
+BLIP_MODEL_PATH = os.path.join(MODEL_BASE, CONFIG["model"]["blip2"])
+GLM_URL = CONFIG["api"]["glm_url"]
+
+processor = Blip2Processor.from_pretrained(BLIP_MODEL_PATH)
+blip_model = Blip2ForConditionalGeneration.from_pretrained(BLIP_MODEL_PATH).to("cuda")
 CSV_PATH = "V1generated_user_cards.csv"
 
 def init_csv():
@@ -99,8 +107,10 @@ traits, writing_style, emotional_patterns, default_needs, attachment_style, prof
 """
 
     # 智谱GLM-4的API参数
-    glm_api_key = "dfc68f67202b4cd393696875e674f576.6l5EvXiEsOzyRhuN"
-    glm_api_url = "https://open.bigmodel.cn/api/paas/v4/chat/completions"
+    glm_api_key = os.getenv("GLM_API_KEY")
+    glm_api_url = GLM_URL
+    if not glm_api_key:
+        raise RuntimeError("GLM_API_KEY environment variable not set")
 
     headers = {
         "Authorization": f"Bearer {glm_api_key}",

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,7 @@
+[model]
+base_dir = "/root/autodl-fs"
+blip2 = "Salesforce/blip2-opt-2.7b"
+embed = "BAAI/bge-base-zh-v1.5"
+
+[api]
+glm_url = "https://open.bigmodel.cn/api/paas/v4/chat/completions"

--- a/save.py
+++ b/save.py
@@ -1,8 +1,10 @@
+import os
 import pandas as pd
 import numpy as np
 import re
 from sentence_transformers import SentenceTransformer
 from typing import List
+import tomllib
 
 DATA_PATH = "V1generated_user_cards.csv"
 PKL_PATH = "/root/autodl-tmp/Bixing_API/ai_search/V1_user_vec.pkl"
@@ -12,8 +14,11 @@ MODEL_NAME = "BAAI/bge-base-zh"
 
 def generate_embeddings_from_csv():
     print("🚀 载入模型中...")
-    # embed_model = SentenceTransformer("BAAI/bge-base-zh", device="cuda")
-    embed_model = SentenceTransformer("BAAI/bge-base-zh-v1.5", device="cuda")
+    with open("config.toml", "rb") as f:
+        cfg = tomllib.load(f)
+    base = cfg["model"]["base_dir"]
+    embed_path = os.path.join(base, cfg["model"]["embed"])
+    embed_model = SentenceTransformer(embed_path, device="cuda")
 
     print("📄 读取 CSV 数据...")
     df = pd.read_csv(DATA_PATH)


### PR DESCRIPTION
## Summary
- load BLIP2 and embedding models from a configurable directory
- add `config.toml` for model paths and API endpoint
- read GLM API key from `GLM_API_KEY` environment variable

## Testing
- `python -m py_compile call_mutilmodal.py save.py receive.py sender.py stop_serve.py`

------
https://chatgpt.com/codex/tasks/task_e_6889c02ec7dc8332be168e8394cd5aef